### PR TITLE
Fix the fake platform's implementation of ConfigurationManagerImpl.

### DIFF
--- a/src/platform/fake/BUILD.gn
+++ b/src/platform/fake/BUILD.gn
@@ -21,6 +21,7 @@ assert(chip_device_platform == "fake")
 static_library("fake") {
   sources = [
     "CHIPDevicePlatformEvent.h",
+    "ConfigurationManagerImpl.cpp",
     "ConfigurationManagerImpl.h",
     "ConnectivityManagerImpl.cpp",
     "ConnectivityManagerImpl.h",

--- a/src/platform/fake/ConfigurationManagerImpl.cpp
+++ b/src/platform/fake/ConfigurationManagerImpl.cpp
@@ -1,0 +1,30 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    limitations under the License.
+ */
+
+#include <platform/ConfigurationManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
+{
+    static ConfigurationManagerImpl sInstance;
+    return sInstance;
+}
+
+ConfigurationManager & ConfigurationMgr()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
+void SetConfigurationMgr(ConfigurationManager * configurationManager) {}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -29,6 +29,9 @@ class ConfigurationManagerImpl : public ConfigurationManager
 {
 public:
     virtual ~ConfigurationManagerImpl() = default;
+    // NOTE: This method is required by the tests.
+    // This returns an instance of this class.
+    static ConfigurationManagerImpl & GetDefaultInstance();
 
 private:
     CHIP_ERROR Init() override { return CHIP_NO_ERROR; }
@@ -104,14 +107,6 @@ private:
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 };
-
-ConfigurationManager & ConfigurationMgr()
-{
-    static ConfigurationManagerImpl sInstance;
-    return sInstance;
-}
-
-void SetConfigurationMgr(ConfigurationManagerImpl * configurationManager) {}
 
 } // namespace DeviceLayer
 } // namespace chip


### PR DESCRIPTION
#### Problem
The fake platform's ConfigurationManagerImpl wasn't properly updated with the recent changes.

#### Change overview
* Move the global methods to the implementation.
* Add ConfigurationManagerImpl::GetDefaultInstance, which is required by tests.

#### Testing
* 