### PR TITLE
Remove confmgr crtp

### DIFF
--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -49,7 +49,7 @@ class DeviceControlServer;
 class FabricProvisioningServer;
 class ServiceProvisioningServer;
 class BLEManagerImpl;
-template <class>
+template <class, class>
 class GenericConfigurationManagerImpl;
 template <class>
 class GenericPlatformManagerImpl;
@@ -239,7 +239,7 @@ private:
     friend class Internal::GenericThreadStackManagerImpl_OpenThread;
     template <class>
     friend class Internal::GenericThreadStackManagerImpl_OpenThread_LwIP;
-    template <class>
+    template <class, class>
     friend class Internal::GenericConfigurationManagerImpl;
     friend class System::PlatformEventing;
 

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -49,7 +49,7 @@ class DeviceControlServer;
 class FabricProvisioningServer;
 class ServiceProvisioningServer;
 class BLEManagerImpl;
-template <class, class>
+template <class>
 class GenericConfigurationManagerImpl;
 template <class>
 class GenericPlatformManagerImpl;
@@ -239,7 +239,7 @@ private:
     friend class Internal::GenericThreadStackManagerImpl_OpenThread;
     template <class>
     friend class Internal::GenericThreadStackManagerImpl_OpenThread_LwIP;
-    template <class, class>
+    template <class>
     friend class Internal::GenericConfigurationManagerImpl;
     friend class System::PlatformEventing;
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -200,7 +200,8 @@ inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreProductRevi
 }
 
 template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetManufacturingDate(uint16_t & year, uint8_t & month,
+                                                                              uint8_t & dayOfMonth)
 {
     CHIP_ERROR err;
     enum

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -44,8 +44,8 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::Init()
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     mLifetimePersistedCounter.Init(CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY);
@@ -54,32 +54,32 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::Init()
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetVendorName(char * buf, size_t bufSize)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetVendorName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetProductName(char * buf, size_t bufSize)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetFirmwareRevisionString(char * buf, size_t bufSize)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetFirmwareRevisionString(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSerialNumber(char * buf, size_t bufSize)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSerialNumber(char * buf, size_t bufSize)
 {
     CHIP_ERROR err;
     size_t serialNumLen = 0; // without counting null-terminator
@@ -103,26 +103,26 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSerialNum
     return err;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreSerialNumber(const char * serialNum, size_t serialNumLen)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreSerialNumber(const char * serialNum, size_t serialNumLen)
 {
     return WriteConfigValueStr(ConfigClass::kConfigKey_SerialNum, serialNum, serialNumLen);
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPrimaryWiFiMACAddress(uint8_t * buf)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StorePrimaryWiFiMACAddress(const uint8_t * buf)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StorePrimaryWiFiMACAddress(const uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPrimaryMACAddress(MutableByteSpan buf)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPrimaryMACAddress(MutableByteSpan buf)
 {
     if (buf.size() != ConfigurationManager::kPrimaryMACAddressLength)
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -149,8 +149,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPrimaryMA
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPrimary802154MACAddress(uint8_t * buf)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPrimary802154MACAddress(uint8_t * buf)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     return ThreadStackManager().GetPrimary802154MACAddress(buf);
@@ -159,22 +159,22 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPrimary80
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StorePrimary802154MACAddress(const uint8_t * buf)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StorePrimary802154MACAddress(const uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetProductRevisionString(char * buf, size_t bufSize)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductRevisionString(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetProductRevision(uint16_t & productRev)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductRevision(uint16_t & productRev)
 {
     CHIP_ERROR err;
     uint32_t val;
@@ -193,14 +193,14 @@ inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPr
     return err;
 }
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreProductRevision(uint16_t productRev)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreProductRevision(uint16_t productRev)
 {
     return WriteConfigValue(ConfigClass::kConfigKey_ProductRevision, static_cast<uint32_t>(productRev));
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
 {
     CHIP_ERROR err;
     enum
@@ -239,14 +239,14 @@ exit:
     return err;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen)
 {
     return WriteConfigValueStr(ConfigClass::kConfigKey_ManufacturingDate, mfgDate, mfgDateLen);
 }
 
-template <class ImplClass, class ConfigClass>
-void GenericConfigurationManagerImpl<ImplClass, ConfigClass>::InitiateFactoryReset()
+template <class ConfigClass>
+void GenericConfigurationManagerImpl<ConfigClass>::InitiateFactoryReset()
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     _IncrementLifetimeCounter();
@@ -254,8 +254,8 @@ void GenericConfigurationManagerImpl<ImplClass, ConfigClass>::InitiateFactoryRes
     // Inheriting classes should call this method so the lifetime counter is updated if necessary.
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSetupPinCode(uint32_t & setupPinCode)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSetupPinCode(uint32_t & setupPinCode)
 {
     CHIP_ERROR err;
 
@@ -273,14 +273,14 @@ exit:
     return err;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreSetupPinCode(uint32_t setupPinCode)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreSetupPinCode(uint32_t setupPinCode)
 {
     return WriteConfigValue(ConfigClass::kConfigKey_SetupPinCode, setupPinCode);
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSetupDiscriminator(uint16_t & setupDiscriminator)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSetupDiscriminator(uint16_t & setupDiscriminator)
 {
     CHIP_ERROR err;
     uint32_t val;
@@ -301,44 +301,44 @@ exit:
     return err;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreSetupDiscriminator(uint16_t setupDiscriminator)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreSetupDiscriminator(uint16_t setupDiscriminator)
 {
     return WriteConfigValue(ConfigClass::kConfigKey_SetupDiscriminator, static_cast<uint32_t>(setupDiscriminator));
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetRegulatoryLocation(uint32_t & location)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetRegulatoryLocation(uint32_t & location)
 {
     return ReadConfigValue(ConfigClass::kConfigKey_RegulatoryLocation, location);
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreRegulatoryLocation(uint32_t location)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreRegulatoryLocation(uint32_t location)
 {
     return WriteConfigValue(ConfigClass::kConfigKey_RegulatoryLocation, location);
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
 {
     return ReadConfigValueStr(ConfigClass::kConfigKey_CountryCode, buf, bufSize, codeLen);
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreCountryCode(const char * code, size_t codeLen)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreCountryCode(const char * code, size_t codeLen)
 {
     return WriteConfigValueStr(ConfigClass::kConfigKey_CountryCode, code, codeLen);
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetBreadcrumb(uint64_t & breadcrumb)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetBreadcrumb(uint64_t & breadcrumb)
 {
     return ReadConfigValue(ConfigClass::kConfigKey_Breadcrumb, breadcrumb);
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreBreadcrumb(uint64_t breadcrumb)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreBreadcrumb(uint64_t breadcrumb)
 {
     return WriteConfigValue(ConfigClass::kConfigKey_Breadcrumb, breadcrumb);
 }
@@ -380,35 +380,35 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreBootReasons(uint32_t
 }
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetLifetimeCounter(uint16_t & lifetimeCounter)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetLifetimeCounter(uint16_t & lifetimeCounter)
 {
     lifetimeCounter = static_cast<uint16_t>(mLifetimePersistedCounter.GetValue());
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::_IncrementLifetimeCounter()
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::_IncrementLifetimeCounter()
 {
     return mLifetimePersistedCounter.Advance();
 }
 #endif
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetFailSafeArmed(bool & val)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetFailSafeArmed(bool & val)
 {
     return ReadConfigValue(ConfigClass::kConfigKey_FailSafeArmed, val);
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::SetFailSafeArmed(bool val)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::SetFailSafeArmed(bool val)
 {
     return WriteConfigValue(ConfigClass::kConfigKey_FailSafeArmed, val);
 }
 
-template <class ImplClass, class ConfigClass>
+template <class ConfigClass>
 CHIP_ERROR
-GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo)
+GenericConfigurationManagerImpl<ConfigClass>::GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo)
 {
     CHIP_ERROR err;
     uint16_t id;
@@ -432,8 +432,8 @@ exit:
     return err;
 }
 
-template <class ImplClass, class ConfigClass>
-bool GenericConfigurationManagerImpl<ImplClass, ConfigClass>::IsFullyProvisioned()
+template <class ConfigClass>
+bool GenericConfigurationManagerImpl<ConfigClass>::IsFullyProvisioned()
 {
 #if CHIP_BYPASS_RENDEZVOUS
     return true;
@@ -450,8 +450,8 @@ bool GenericConfigurationManagerImpl<ImplClass, ConfigClass>::IsFullyProvisioned
 #endif // CHIP_BYPASS_RENDEZVOUS
 }
 
-template <class ImplClass, class ConfigClass>
-bool GenericConfigurationManagerImpl<ImplClass, ConfigClass>::IsCommissionableDeviceTypeEnabled()
+template <class ConfigClass>
+bool GenericConfigurationManagerImpl<ConfigClass>::IsCommissionableDeviceTypeEnabled()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_TYPE
     return true;
@@ -460,30 +460,30 @@ bool GenericConfigurationManagerImpl<ImplClass, ConfigClass>::IsCommissionableDe
 #endif
 }
 
-template <class ImplClass, class ConfigClass>
-bool GenericConfigurationManagerImpl<ImplClass, ConfigClass>::IsCommissionableDeviceNameEnabled()
+template <class ConfigClass>
+bool GenericConfigurationManagerImpl<ConfigClass>::IsCommissionableDeviceNameEnabled()
 {
     return CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_NAME == 1;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetCommissionableDeviceName(char * buf, size_t bufSize)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetCommissionableDeviceName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetInitialPairingInstruction(char * buf, size_t bufSize)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetInitialPairingInstruction(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_PAIRING_INITIAL_INSTRUCTION), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_PAIRING_INITIAL_INSTRUCTION);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSecondaryPairingInstruction(char * buf, size_t bufSize)
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSecondaryPairingInstruction(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_INSTRUCTION), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_INSTRUCTION);
@@ -491,8 +491,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSecondary
 }
 
 #if !defined(NDEBUG)
-template <class ImplClass, class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::RunUnitTests()
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::RunUnitTests()
 {
     ChipLogProgress(DeviceLayer, "Running configuration unit test");
     RunConfigUnitTest();
@@ -501,8 +501,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::RunUnitTests
 }
 #endif
 
-template <class ImplClass, class ConfigClass>
-void GenericConfigurationManagerImpl<ImplClass, ConfigClass>::LogDeviceConfig()
+template <class ConfigClass>
+void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()
 {
     CHIP_ERROR err;
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -583,9 +583,6 @@ void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()
     }
 }
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-// template class GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -44,8 +44,8 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::Init()
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::Init()
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     mLifetimePersistedCounter.Init(CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY);
@@ -54,36 +54,36 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::Init()
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetVendorName(char * buf, size_t bufSize)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetVendorName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductName(char * buf, size_t bufSize)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetProductName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFirmwareRevisionString(char * buf, size_t bufSize)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetFirmwareRevisionString(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSerialNumber(char * buf, size_t bufSize)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSerialNumber(char * buf, size_t bufSize)
 {
     CHIP_ERROR err;
     size_t serialNumLen = 0; // without counting null-terminator
-    err                 = Impl()->ReadConfigValueStr(ImplClass::kConfigKey_SerialNum, buf, bufSize, serialNumLen);
+    err                 = ReadConfigValueStr(ConfigClass::kConfigKey_SerialNum, buf, bufSize, serialNumLen);
 
 #ifdef CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER
     if (CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER[0] != 0 && err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -103,26 +103,26 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSerialNumber(char * bu
     return err;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreSerialNumber(const char * serialNum, size_t serialNumLen)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreSerialNumber(const char * serialNum, size_t serialNumLen)
 {
-    return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_SerialNum, serialNum, serialNumLen);
+    return WriteConfigValueStr(ConfigClass::kConfigKey_SerialNum, serialNum, serialNumLen);
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetPrimaryWiFiMACAddress(uint8_t * buf)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StorePrimaryWiFiMACAddress(const uint8_t * buf)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StorePrimaryWiFiMACAddress(const uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetPrimaryMACAddress(MutableByteSpan buf)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPrimaryMACAddress(MutableByteSpan buf)
 {
     if (buf.size() != ConfigurationManager::kPrimaryMACAddressLength)
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -149,8 +149,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetPrimaryMACAddress(Muta
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetPrimary802154MACAddress(uint8_t * buf)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetPrimary802154MACAddress(uint8_t * buf)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     return ThreadStackManager().GetPrimary802154MACAddress(buf);
@@ -159,27 +159,27 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetPrimary802154MACAddres
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StorePrimary802154MACAddress(const uint8_t * buf)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StorePrimary802154MACAddress(const uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductRevisionString(char * buf, size_t bufSize)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetProductRevisionString(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductRevision(uint16_t & productRev)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetProductRevision(uint16_t & productRev)
 {
     CHIP_ERROR err;
     uint32_t val;
 
-    err = Impl()->ReadConfigValue(ImplClass::kConfigKey_ProductRevision, val);
+    err = ReadConfigValue(ConfigClass::kConfigKey_ProductRevision, val);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         productRev = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION);
@@ -193,14 +193,14 @@ inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductRevision
     return err;
 }
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreProductRevision(uint16_t productRev)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreProductRevision(uint16_t productRev)
 {
-    return Impl()->WriteConfigValue(ImplClass::kConfigKey_ProductRevision, static_cast<uint32_t>(productRev));
+    return WriteConfigValue(ConfigClass::kConfigKey_ProductRevision, static_cast<uint32_t>(productRev));
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
 {
     CHIP_ERROR err;
     enum
@@ -211,7 +211,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetManufacturingDate(uint
     size_t dateLen;
     char * parseEnd;
 
-    err = Impl()->ReadConfigValueStr(ImplClass::kConfigKey_ManufacturingDate, dateStr, sizeof(dateStr), dateLen);
+    err = ReadConfigValueStr(ConfigClass::kConfigKey_ManufacturingDate, dateStr, sizeof(dateStr), dateLen);
     SuccessOrExit(err);
 
     VerifyOrExit(dateLen == kDateStringLength, err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -239,14 +239,14 @@ exit:
     return err;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen)
 {
-    return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_ManufacturingDate, mfgDate, mfgDateLen);
+    return WriteConfigValueStr(ConfigClass::kConfigKey_ManufacturingDate, mfgDate, mfgDateLen);
 }
 
-template <class ImplClass>
-void GenericConfigurationManagerImpl<ImplClass>::InitiateFactoryReset()
+template <class ImplClass, class ConfigClass>
+void GenericConfigurationManagerImpl<ImplClass, ConfigClass>::InitiateFactoryReset()
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     _IncrementLifetimeCounter();
@@ -254,12 +254,12 @@ void GenericConfigurationManagerImpl<ImplClass>::InitiateFactoryReset()
     // Inheriting classes should call this method so the lifetime counter is updated if necessary.
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSetupPinCode(uint32_t & setupPinCode)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSetupPinCode(uint32_t & setupPinCode)
 {
     CHIP_ERROR err;
 
-    err = Impl()->ReadConfigValue(ImplClass::kConfigKey_SetupPinCode, setupPinCode);
+    err = ReadConfigValue(ConfigClass::kConfigKey_SetupPinCode, setupPinCode);
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -273,19 +273,19 @@ exit:
     return err;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreSetupPinCode(uint32_t setupPinCode)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreSetupPinCode(uint32_t setupPinCode)
 {
-    return Impl()->WriteConfigValue(ImplClass::kConfigKey_SetupPinCode, setupPinCode);
+    return WriteConfigValue(ConfigClass::kConfigKey_SetupPinCode, setupPinCode);
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSetupDiscriminator(uint16_t & setupDiscriminator)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSetupDiscriminator(uint16_t & setupDiscriminator)
 {
     CHIP_ERROR err;
     uint32_t val;
 
-    err = Impl()->ReadConfigValue(ImplClass::kConfigKey_SetupDiscriminator, val);
+    err = ReadConfigValue(ConfigClass::kConfigKey_SetupDiscriminator, val);
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -301,46 +301,46 @@ exit:
     return err;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreSetupDiscriminator(uint16_t setupDiscriminator)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreSetupDiscriminator(uint16_t setupDiscriminator)
 {
-    return Impl()->WriteConfigValue(ImplClass::kConfigKey_SetupDiscriminator, static_cast<uint32_t>(setupDiscriminator));
+    return WriteConfigValue(ConfigClass::kConfigKey_SetupDiscriminator, static_cast<uint32_t>(setupDiscriminator));
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetRegulatoryLocation(uint32_t & location)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetRegulatoryLocation(uint32_t & location)
 {
-    return Impl()->ReadConfigValue(ImplClass::kConfigKey_RegulatoryLocation, location);
+    return ReadConfigValue(ConfigClass::kConfigKey_RegulatoryLocation, location);
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreRegulatoryLocation(uint32_t location)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreRegulatoryLocation(uint32_t location)
 {
-    return Impl()->WriteConfigValue(ImplClass::kConfigKey_RegulatoryLocation, location);
+    return WriteConfigValue(ConfigClass::kConfigKey_RegulatoryLocation, location);
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
 {
-    return Impl()->ReadConfigValueStr(ImplClass::kConfigKey_CountryCode, buf, bufSize, codeLen);
+    return ReadConfigValueStr(ConfigClass::kConfigKey_CountryCode, buf, bufSize, codeLen);
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreCountryCode(const char * code, size_t codeLen)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreCountryCode(const char * code, size_t codeLen)
 {
-    return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_CountryCode, code, codeLen);
+    return WriteConfigValueStr(ConfigClass::kConfigKey_CountryCode, code, codeLen);
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetBreadcrumb(uint64_t & breadcrumb)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetBreadcrumb(uint64_t & breadcrumb)
 {
-    return Impl()->ReadConfigValue(ImplClass::kConfigKey_Breadcrumb, breadcrumb);
+    return ReadConfigValue(ConfigClass::kConfigKey_Breadcrumb, breadcrumb);
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreBreadcrumb(uint64_t breadcrumb)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::StoreBreadcrumb(uint64_t breadcrumb)
 {
-    return Impl()->WriteConfigValue(ImplClass::kConfigKey_Breadcrumb, breadcrumb);
+    return WriteConfigValue(ConfigClass::kConfigKey_Breadcrumb, breadcrumb);
 }
 
 template <class ImplClass>
@@ -380,35 +380,35 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreBootReasons(uint32_t
 }
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetLifetimeCounter(uint16_t & lifetimeCounter)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetLifetimeCounter(uint16_t & lifetimeCounter)
 {
     lifetimeCounter = static_cast<uint16_t>(mLifetimePersistedCounter.GetValue());
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_IncrementLifetimeCounter()
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::_IncrementLifetimeCounter()
 {
     return mLifetimePersistedCounter.Advance();
 }
 #endif
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFailSafeArmed(bool & val)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetFailSafeArmed(bool & val)
 {
-    return Impl()->ReadConfigValue(ImplClass::kConfigKey_FailSafeArmed, val);
+    return ReadConfigValue(ConfigClass::kConfigKey_FailSafeArmed, val);
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::SetFailSafeArmed(bool val)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::SetFailSafeArmed(bool val)
 {
-    return Impl()->WriteConfigValue(ImplClass::kConfigKey_FailSafeArmed, val);
+    return WriteConfigValue(ConfigClass::kConfigKey_FailSafeArmed, val);
 }
 
-template <class ImplClass>
+template <class ImplClass, class ConfigClass>
 CHIP_ERROR
-GenericConfigurationManagerImpl<ImplClass>::GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo)
+GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo)
 {
     CHIP_ERROR err;
     uint16_t id;
@@ -432,8 +432,8 @@ exit:
     return err;
 }
 
-template <class ImplClass>
-bool GenericConfigurationManagerImpl<ImplClass>::IsFullyProvisioned()
+template <class ImplClass, class ConfigClass>
+bool GenericConfigurationManagerImpl<ImplClass, ConfigClass>::IsFullyProvisioned()
 {
 #if CHIP_BYPASS_RENDEZVOUS
     return true;
@@ -450,8 +450,8 @@ bool GenericConfigurationManagerImpl<ImplClass>::IsFullyProvisioned()
 #endif // CHIP_BYPASS_RENDEZVOUS
 }
 
-template <class ImplClass>
-bool GenericConfigurationManagerImpl<ImplClass>::IsCommissionableDeviceTypeEnabled()
+template <class ImplClass, class ConfigClass>
+bool GenericConfigurationManagerImpl<ImplClass, ConfigClass>::IsCommissionableDeviceTypeEnabled()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_TYPE
     return true;
@@ -460,30 +460,30 @@ bool GenericConfigurationManagerImpl<ImplClass>::IsCommissionableDeviceTypeEnabl
 #endif
 }
 
-template <class ImplClass>
-bool GenericConfigurationManagerImpl<ImplClass>::IsCommissionableDeviceNameEnabled()
+template <class ImplClass, class ConfigClass>
+bool GenericConfigurationManagerImpl<ImplClass, ConfigClass>::IsCommissionableDeviceNameEnabled()
 {
     return CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_NAME == 1;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetCommissionableDeviceName(char * buf, size_t bufSize)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetCommissionableDeviceName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetInitialPairingInstruction(char * buf, size_t bufSize)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetInitialPairingInstruction(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_PAIRING_INITIAL_INSTRUCTION), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_PAIRING_INITIAL_INSTRUCTION);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSecondaryPairingInstruction(char * buf, size_t bufSize)
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSecondaryPairingInstruction(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_INSTRUCTION), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_INSTRUCTION);
@@ -491,18 +491,18 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSecondaryPairingInstru
 }
 
 #if !defined(NDEBUG)
-template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::RunUnitTests()
+template <class ImplClass, class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::RunUnitTests()
 {
     ChipLogProgress(DeviceLayer, "Running configuration unit test");
-    Impl()->RunConfigUnitTest();
+    RunConfigUnitTest();
 
     return CHIP_NO_ERROR;
 }
 #endif
 
-template <class ImplClass>
-void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
+template <class ImplClass, class ConfigClass>
+void GenericConfigurationManagerImpl<ImplClass, ConfigClass>::LogDeviceConfig()
 {
     CHIP_ERROR err;
 
@@ -584,7 +584,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 }
 
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+// template class GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -47,7 +47,7 @@ namespace Internal {
  * or indirectly) by the ConfigurationManagerImpl class, which also appears as the template's ImplClass
  * parameter.
  */
-template <class ImplClass, class ConfigClass>
+template <class ConfigClass>
 class GenericConfigurationManagerImpl : public ConfigurationManager
 {
 public:
@@ -132,51 +132,48 @@ protected:
     virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) = 0;
     virtual CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) = 0;
     virtual void RunConfigUnitTest(void) = 0;
-
-private:
-    ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
 
 // Instruct the compiler to instantiate the template only when explicitly told to do so.
 // extern template class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetVendorId(uint16_t & vendorId)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetVendorId(uint16_t & vendorId)
 {
     vendorId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetProductId(uint16_t & productId)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductId(uint16_t & productId)
 {
     productId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetFirmwareRevision(uint16_t & firmwareRev)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetFirmwareRevision(uint16_t & firmwareRev)
 {
     firmwareRev = static_cast<uint32_t>(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetDeviceTypeId(uint16_t & deviceType)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetDeviceTypeId(uint16_t & deviceType)
 {
     deviceType = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_TYPE);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetInitialPairingHint(uint16_t & pairingHint)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetInitialPairingHint(uint16_t & pairingHint)
 {
     pairingHint = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_PAIRING_INITIAL_HINT);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass, class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSecondaryPairingHint(uint16_t & pairingHint)
+template <class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSecondaryPairingHint(uint16_t & pairingHint)
 {
     pairingHint = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_HINT);
     return CHIP_NO_ERROR;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -47,7 +47,7 @@ namespace Internal {
  * or indirectly) by the ConfigurationManagerImpl class, which also appears as the template's ImplClass
  * parameter.
  */
-template <class ImplClass>
+template <class ImplClass, class ConfigClass>
 class GenericConfigurationManagerImpl : public ConfigurationManager
 {
 public:
@@ -118,50 +118,65 @@ protected:
 #endif
     CHIP_ERROR PersistProvisioningData(ProvisioningDataSet & provData);
 
+    // Methods to read and write configuration values, as well as run the configuration unit test.
+    typedef typename ConfigClass::Key Key;
+    virtual CHIP_ERROR ReadConfigValue(Key key, bool & val) = 0;
+    virtual CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) = 0;
+    virtual CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) = 0;
+    virtual CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) = 0;
+    virtual CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) = 0;
+    virtual CHIP_ERROR WriteConfigValue(Key key, bool val) = 0;
+    virtual CHIP_ERROR WriteConfigValue(Key key, uint32_t val) = 0;
+    virtual CHIP_ERROR WriteConfigValue(Key key, uint64_t val) = 0;
+    virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str) = 0;
+    virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) = 0;
+    virtual CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) = 0;
+    virtual void RunConfigUnitTest(void) = 0;
+
 private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
 
 // Instruct the compiler to instantiate the template only when explicitly told to do so.
-extern template class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+// extern template class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetVendorId(uint16_t & vendorId)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetVendorId(uint16_t & vendorId)
 {
     vendorId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductId(uint16_t & productId)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetProductId(uint16_t & productId)
 {
     productId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFirmwareRevision(uint16_t & firmwareRev)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetFirmwareRevision(uint16_t & firmwareRev)
 {
     firmwareRev = static_cast<uint32_t>(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetDeviceTypeId(uint16_t & deviceType)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetDeviceTypeId(uint16_t & deviceType)
 {
     deviceType = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_TYPE);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetInitialPairingHint(uint16_t & pairingHint)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetInitialPairingHint(uint16_t & pairingHint)
 {
     pairingHint = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_PAIRING_INITIAL_HINT);
     return CHIP_NO_ERROR;
 }
 
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSecondaryPairingHint(uint16_t & pairingHint)
+template <class ImplClass, class ConfigClass>
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass, ConfigClass>::GetSecondaryPairingHint(uint16_t & pairingHint)
 {
     pairingHint = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_HINT);
     return CHIP_NO_ERROR;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -44,8 +44,7 @@ namespace Internal {
  *
  * This template contains implementations of select features from the ConfigurationManager abstract
  * interface that are suitable for use on all platforms.  It is intended to be inherited (directly
- * or indirectly) by the ConfigurationManagerImpl class, which also appears as the template's ImplClass
- * parameter.
+ * or indirectly) by the ConfigurationManagerImpl class.
  */
 template <class ConfigClass>
 class GenericConfigurationManagerImpl : public ConfigurationManager
@@ -133,9 +132,6 @@ protected:
     virtual CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) = 0;
     virtual void RunConfigUnitTest(void) = 0;
 };
-
-// Instruct the compiler to instantiate the template only when explicitly told to do so.
-// extern template class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
 
 template <class ConfigClass>
 inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetVendorId(uint16_t & vendorId)

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -119,18 +119,18 @@ protected:
 
     // Methods to read and write configuration values, as well as run the configuration unit test.
     typedef typename ConfigClass::Key Key;
-    virtual CHIP_ERROR ReadConfigValue(Key key, bool & val) = 0;
-    virtual CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) = 0;
-    virtual CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) = 0;
-    virtual CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) = 0;
+    virtual CHIP_ERROR ReadConfigValue(Key key, bool & val)                                        = 0;
+    virtual CHIP_ERROR ReadConfigValue(Key key, uint32_t & val)                                    = 0;
+    virtual CHIP_ERROR ReadConfigValue(Key key, uint64_t & val)                                    = 0;
+    virtual CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)    = 0;
     virtual CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) = 0;
-    virtual CHIP_ERROR WriteConfigValue(Key key, bool val) = 0;
-    virtual CHIP_ERROR WriteConfigValue(Key key, uint32_t val) = 0;
-    virtual CHIP_ERROR WriteConfigValue(Key key, uint64_t val) = 0;
-    virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str) = 0;
-    virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) = 0;
-    virtual CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) = 0;
-    virtual void RunConfigUnitTest(void) = 0;
+    virtual CHIP_ERROR WriteConfigValue(Key key, bool val)                                         = 0;
+    virtual CHIP_ERROR WriteConfigValue(Key key, uint32_t val)                                     = 0;
+    virtual CHIP_ERROR WriteConfigValue(Key key, uint64_t val)                                     = 0;
+    virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str)                              = 0;
+    virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen)               = 0;
+    virtual CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)          = 0;
+    virtual void RunConfigUnitTest(void)                                                           = 0;
 };
 
 template <class ConfigClass>

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipCounters);
     SuccessOrExit(err);
 
-    if (ConfigValueExists(kCounterKey_RebootCount))
+    if (AmebaConfig::ConfigValueExists(AmebaConfig::kCounterKey_RebootCount))
     {
         err = GetRebootCount(rebootCount);
         SuccessOrExit(err);
@@ -74,13 +74,13 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    if (!ConfigValueExists(kCounterKey_TotalOperationalHours))
+    if (!AmebaConfig::ConfigValueExists(kAmebaConfig::CounterKey_TotalOperationalHours))
     {
         err = StoreTotalOperationalHours(0);
         SuccessOrExit(err);
     }
 
-    if (!ConfigValueExists(kCounterKey_BootReason))
+    if (!AmebaConfig::ConfigValueExists(AmebaConfig::kCounterKey_BootReason))
     {
         err = StoreBootReasons(EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED);
         SuccessOrExit(err);
@@ -104,32 +104,32 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 {
-    return ReadConfigValue(kCounterKey_RebootCount, rebootCount);
+    return ReadConfigValue(AmebaConfig::kCounterKey_RebootCount, rebootCount);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
 {
-    return WriteConfigValue(kCounterKey_RebootCount, rebootCount);
+    return WriteConfigValue(AmebaConfig::kCounterKey_RebootCount, rebootCount);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
-    return ReadConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
+    return ReadConfigValue(AmebaConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
 {
-    return WriteConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
+    return WriteConfigValue(AmebaConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetBootReasons(uint32_t & bootReasons)
 {
-    return ReadConfigValue(kCounterKey_BootReason, bootReasons);
+    return ReadConfigValue(AmebaConfig::kCounterKey_BootReason, bootReasons);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreBootReasons(uint32_t bootReasons)
 {
-    return WriteConfigValue(kCounterKey_BootReason, bootReasons);
+    return WriteConfigValue(AmebaConfig::kCounterKey_BootReason, bootReasons);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
@@ -242,7 +242,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
     // Erase all values in the chip-config NVS namespace.
-    err = AmebaConfig::ClearNamespace(kConfigNamespace_ChipConfig);
+    err = AmebaConfig::ClearNamespace(AmebaConfig::kConfigNamespace_ChipConfig);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "ClearNamespace(ChipConfig) failed: %s", chip::ErrorStr(err));

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -33,6 +33,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<AmebaConfig>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -49,11 +52,11 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Force initialization of NVS namespaces if they doesn't already exist.
-    err = EnsureNamespace(kConfigNamespace_ChipFactory);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipFactory);
     SuccessOrExit(err);
-    err = EnsureNamespace(kConfigNamespace_ChipConfig);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipConfig);
     SuccessOrExit(err);
-    err = EnsureNamespace(kConfigNamespace_ChipCounters);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipCounters);
     SuccessOrExit(err);
 
     if (ConfigValueExists(kCounterKey_RebootCount))
@@ -84,7 +87,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     }
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<AmebaConfig>::Init();
     SuccessOrExit(err);
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
@@ -156,7 +159,7 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    AmebaConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
+    AmebaConfig::Key configKey{ AmebaConfig::kConfigNamespace_ChipCounters, key };
 
     CHIP_ERROR err = ReadConfigValue(configKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -168,8 +171,68 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    AmebaConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
+    AmebaConfig::Key configKey{ AmebaConfig::kConfigNamespace_ChipCounters, key };
     return WriteConfigValue(configKey, value);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AmebaConfig::Key key, bool & val)
+{
+    return AmebaConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AmebaConfig::Key key, uint32_t & val)
+{
+    return AmebaConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AmebaConfig::Key key, uint64_t & val)
+{
+    return AmebaConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(AmebaConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return AmebaConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(AmebaConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return AmebaConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AmebaConfig::Key key, bool val)
+{
+    return AmebaConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AmebaConfig::Key key, uint32_t val)
+{
+    return AmebaConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AmebaConfig::Key key, uint64_t val)
+{
+    return AmebaConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(AmebaConfig::Key key, const char * str)
+{
+    return AmebaConfig::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(AmebaConfig::Key key, const char * str, size_t strLen)
+{
+    return AmebaConfig::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(AmebaConfig::Key key, const uint8_t * data, size_t dataLen)
+{
+    return AmebaConfig::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    AmebaConfig::RunConfigUnitTest();
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
@@ -179,7 +242,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
     // Erase all values in the chip-config NVS namespace.
-    err = ClearNamespace(kConfigNamespace_ChipConfig);
+    err = AmebaConfig::ClearNamespace(kConfigNamespace_ChipConfig);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "ClearNamespace(ChipConfig) failed: %s", chip::ErrorStr(err));

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -74,7 +74,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    if (!AmebaConfig::ConfigValueExists(kAmebaConfig::CounterKey_TotalOperationalHours))
+    if (!AmebaConfig::ConfigValueExists(AmebaConfig::kCounterKey_TotalOperationalHours))
     {
         err = StoreTotalOperationalHours(0);
         SuccessOrExit(err);
@@ -175,57 +175,57 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return WriteConfigValue(configKey, value);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AmebaConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return AmebaConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AmebaConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return AmebaConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AmebaConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return AmebaConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(AmebaConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return AmebaConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(AmebaConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return AmebaConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AmebaConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return AmebaConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AmebaConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return AmebaConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AmebaConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return AmebaConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(AmebaConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return AmebaConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(AmebaConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return AmebaConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(AmebaConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return AmebaConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -33,9 +33,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<AmebaConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -34,20 +34,13 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Ameba platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::AmebaConfig
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::AmebaConfig>
 {
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 
 private:
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
     // ===== Members that implement the ConfigurationManager public interface.
 
     CHIP_ERROR Init(void) override;
@@ -64,6 +57,20 @@ private:
     CHIP_ERROR StoreBootReasons(uint32_t bootReasons) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -46,7 +46,7 @@
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
-template class GenericConfigurationManagerImpl<ConfigurationManagerImpl, PosixConfig>;
+template class GenericConfigurationManagerImpl<PosixConfig>;
 } // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
@@ -142,7 +142,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     CHIP_ERROR err;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl, PosixConfig>::Init();
+    err = Internal::GenericConfigurationManagerImpl<PosixConfig>::Init();
     SuccessOrExit(err);
 
 exit:

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -45,6 +45,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<ConfigurationManagerImpl, PosixConfig>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -139,7 +142,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     CHIP_ERROR err;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl, PosixConfig>::Init();
     SuccessOrExit(err);
 
 exit:
@@ -177,7 +180,7 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
+    PosixConfig::Key configKey{ PosixConfig::kConfigNamespace_ChipCounters, key };
 
     CHIP_ERROR err = ReadConfigValue(configKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -189,8 +192,68 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
+    PosixConfig::Key configKey{ PosixConfig::kConfigNamespace_ChipCounters, key };
     return WriteConfigValue(configKey, value);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, bool & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint32_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint64_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(PosixConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(PosixConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, bool val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint32_t val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint64_t val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str)
+{
+    return PosixConfig::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str, size_t strLen)
+{
+    return PosixConfig::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(PosixConfig::Key key, const uint8_t * data, size_t dataLen)
+{
+    return PosixConfig::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    PosixConfig::RunConfigUnitTest();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -45,9 +45,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<PosixConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -196,57 +196,57 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return WriteConfigValue(configKey, value);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(PosixConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(PosixConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return PosixConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return PosixConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(PosixConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -33,13 +33,12 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Darwin platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::PosixConfig
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl, Internal::PosixConfig>
 {
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl, Internal::PosixConfig>;
 #endif
 
 public:
@@ -57,6 +56,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -33,14 +33,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Darwin platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl, Internal::PosixConfig>
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl, Internal::PosixConfig>;
-#endif
-
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -113,57 +113,57 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(EFR32Config::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return EFR32Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(EFR32Config::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return EFR32Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(EFR32Config::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return EFR32Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(EFR32Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return EFR32Config::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(EFR32Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return EFR32Config::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(EFR32Config::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return EFR32Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(EFR32Config::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return EFR32Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(EFR32Config::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return EFR32Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(EFR32Config::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return EFR32Config::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(EFR32Config::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return EFR32Config::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(EFR32Config::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return EFR32Config::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -31,6 +31,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<EFR32Config>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -46,7 +49,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<EFR32Config>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here (#1626)
@@ -81,7 +84,7 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 
-    err = ReadConfigValueCounter(persistedStorageKey, value);
+    err = EFR32Config::ReadConfigValueCounter(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -99,7 +102,7 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 
-    err = WriteConfigValueCounter(persistedStorageKey, value);
+    err = EFR32Config::WriteConfigValueCounter(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -110,13 +113,73 @@ exit:
     return err;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(EFR32Config::Key key, bool & val)
+{
+    return EFR32Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(EFR32Config::Key key, uint32_t & val)
+{
+    return EFR32Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(EFR32Config::Key key, uint64_t & val)
+{
+    return EFR32Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(EFR32Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return EFR32Config::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(EFR32Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return EFR32Config::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(EFR32Config::Key key, bool val)
+{
+    return EFR32Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(EFR32Config::Key key, uint32_t val)
+{
+    return EFR32Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(EFR32Config::Key key, uint64_t val)
+{
+    return EFR32Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(EFR32Config::Key key, const char * str)
+{
+    return EFR32Config::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(EFR32Config::Key key, const char * str, size_t strLen)
+{
+    return EFR32Config::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(EFR32Config::Key key, const uint8_t * data, size_t dataLen)
+{
+    return EFR32Config::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    EFR32Config::RunConfigUnitTest();
+}
+
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = FactoryResetConfig();
+    err = EFR32Config::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", chip::ErrorStr(err));

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -31,9 +31,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<EFR32Config>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/EFR32/ConfigurationManagerImpl.h
+++ b/src/platform/EFR32/ConfigurationManagerImpl.h
@@ -34,15 +34,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the EFR32 platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::EFR32Config
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::EFR32Config>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
@@ -58,6 +51,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -36,9 +36,6 @@
 #include "nvs_flash.h"
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<ESP32Config>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -206,57 +206,57 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return WriteConfigValue(configKey, value);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ESP32Config::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return ESP32Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ESP32Config::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return ESP32Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ESP32Config::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return ESP32Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(ESP32Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return ESP32Config::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(ESP32Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return ESP32Config::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ESP32Config::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return ESP32Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ESP32Config::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return ESP32Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ESP32Config::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return ESP32Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(ESP32Config::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return ESP32Config::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(ESP32Config::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return ESP32Config::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(ESP32Config::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return ESP32Config::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -36,6 +36,9 @@
 #include "nvs_flash.h"
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<ESP32Config>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -63,14 +66,14 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Force initialization of NVS namespaces if they doesn't already exist.
-    err = EnsureNamespace(kConfigNamespace_ChipFactory);
+    err = EnsureNamespace(ESP32Config::kConfigNamespace_ChipFactory);
     SuccessOrExit(err);
-    err = EnsureNamespace(kConfigNamespace_ChipConfig);
+    err = EnsureNamespace(ESP32Config::kConfigNamespace_ChipConfig);
     SuccessOrExit(err);
-    err = EnsureNamespace(kConfigNamespace_ChipCounters);
+    err = EnsureNamespace(ESP32Config::kConfigNamespace_ChipCounters);
     SuccessOrExit(err);
 
-    if (ConfigValueExists(kCounterKey_RebootCount))
+    if (ConfigValueExists(ESP32Config::kCounterKey_RebootCount))
     {
         err = GetRebootCount(rebootCount);
         SuccessOrExit(err);
@@ -85,14 +88,14 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    if (!ConfigValueExists(kCounterKey_TotalOperationalHours))
+    if (!ConfigValueExists(ESP32Config::kCounterKey_TotalOperationalHours))
     {
         err = StoreTotalOperationalHours(0);
         SuccessOrExit(err);
     }
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<ESP32Config>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here (#1266)
@@ -126,22 +129,22 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 {
-    return ReadConfigValue(kCounterKey_RebootCount, rebootCount);
+    return ReadConfigValue(ESP32Config::kCounterKey_RebootCount, rebootCount);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
 {
-    return WriteConfigValue(kCounterKey_RebootCount, rebootCount);
+    return WriteConfigValue(ESP32Config::kCounterKey_RebootCount, rebootCount);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
-    return ReadConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
+    return ReadConfigValue(ESP32Config::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
 {
-    return WriteConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
+    return WriteConfigValue(ESP32Config::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
@@ -187,7 +190,7 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    ESP32Config::Key configKey{ kConfigNamespace_ChipCounters, key };
+    ESP32Config::Key configKey{ ESP32Config::kConfigNamespace_ChipCounters, key };
 
     CHIP_ERROR err = ReadConfigValue(configKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -199,8 +202,68 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    ESP32Config::Key configKey{ kConfigNamespace_ChipCounters, key };
+    ESP32Config::Key configKey{ ESP32Config::kConfigNamespace_ChipCounters, key };
     return WriteConfigValue(configKey, value);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ESP32Config::Key key, bool & val)
+{
+    return ESP32Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ESP32Config::Key key, uint32_t & val)
+{
+    return ESP32Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ESP32Config::Key key, uint64_t & val)
+{
+    return ESP32Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(ESP32Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return ESP32Config::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(ESP32Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return ESP32Config::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ESP32Config::Key key, bool val)
+{
+    return ESP32Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ESP32Config::Key key, uint32_t val)
+{
+    return ESP32Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ESP32Config::Key key, uint64_t val)
+{
+    return ESP32Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(ESP32Config::Key key, const char * str)
+{
+    return ESP32Config::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(ESP32Config::Key key, const char * str, size_t strLen)
+{
+    return ESP32Config::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(ESP32Config::Key key, const uint8_t * data, size_t dataLen)
+{
+    return ESP32Config::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    ESP32Config::RunConfigUnitTest();
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
@@ -210,7 +273,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
     // Erase all values in the chip-config NVS namespace.
-    err = ClearNamespace(kConfigNamespace_ChipConfig);
+    err = ESP32Config::ClearNamespace(ESP32Config::kConfigNamespace_ChipConfig);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "ClearNamespace(ChipConfig) failed: %s", chip::ErrorStr(err));

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -66,14 +66,14 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Force initialization of NVS namespaces if they doesn't already exist.
-    err = EnsureNamespace(ESP32Config::kConfigNamespace_ChipFactory);
+    err = ESP32Config::EnsureNamespace(ESP32Config::kConfigNamespace_ChipFactory);
     SuccessOrExit(err);
-    err = EnsureNamespace(ESP32Config::kConfigNamespace_ChipConfig);
+    err = ESP32Config::EnsureNamespace(ESP32Config::kConfigNamespace_ChipConfig);
     SuccessOrExit(err);
-    err = EnsureNamespace(ESP32Config::kConfigNamespace_ChipCounters);
+    err = ESP32Config::EnsureNamespace(ESP32Config::kConfigNamespace_ChipCounters);
     SuccessOrExit(err);
 
-    if (ConfigValueExists(ESP32Config::kCounterKey_RebootCount))
+    if (ESP32Config::ConfigValueExists(ESP32Config::kCounterKey_RebootCount))
     {
         err = GetRebootCount(rebootCount);
         SuccessOrExit(err);
@@ -88,7 +88,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    if (!ConfigValueExists(ESP32Config::kCounterKey_TotalOperationalHours))
+    if (!ESP32Config::ConfigValueExists(ESP32Config::kCounterKey_TotalOperationalHours))
     {
         err = StoreTotalOperationalHours(0);
         SuccessOrExit(err);

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -41,13 +41,12 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the ESP32 platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::ESP32Config>,
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-                                 public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>,
+                                 public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>
 #else
-                                 public Internal::GenericConnectivityManagerImpl_NoBLE<ConnectivityManagerImpl>,
+                                 public Internal::GenericConnectivityManagerImpl_NoBLE<ConnectivityManagerImpl>
 #endif
-                                 private Internal::ESP32Config
 {
 public:
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
@@ -57,12 +56,6 @@ public:
     static ConfigurationManagerImpl & GetDefaultInstance();
 
 private:
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
     // ===== Members that implement the ConfigurationManager public interface.
 
     CHIP_ERROR Init(void) override;
@@ -74,6 +67,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -56,18 +56,18 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Force initialization of NVS namespaces if they doesn't already exist.
-    err = EnsureNamespace(PosixConfig::kConfigNamespace_ChipFactory);
+    err = PosixConfig::EnsureNamespace(PosixConfig::kConfigNamespace_ChipFactory);
     SuccessOrExit(err);
-    err = EnsureNamespace(PosixConfig::kConfigNamespace_ChipConfig);
+    err = PosixConfig::EnsureNamespace(PosixConfig::kConfigNamespace_ChipConfig);
     SuccessOrExit(err);
-    err = EnsureNamespace(PosixConfig::kConfigNamespace_ChipCounters);
+    err = PosixConfig::EnsureNamespace(PosixConfig::kConfigNamespace_ChipCounters);
     SuccessOrExit(err);
 
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<PosixConfig>::Init();
     SuccessOrExit(err);
 
-    if (ConfigValueExists(PosixConfig::kCounterKey_RebootCount))
+    if (PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_RebootCount))
     {
         err = GetRebootCount(rebootCount);
         SuccessOrExit(err);
@@ -82,13 +82,13 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    if (!ConfigValueExists(PosixConfig::kCounterKey_TotalOperationalHours))
+    if (!PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_TotalOperationalHours))
     {
         err = StoreTotalOperationalHours(0);
         SuccessOrExit(err);
     }
 
-    if (!ConfigValueExists(PosixConfig::kCounterKey_BootReason))
+    if (!PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_BootReason))
     {
         err = StoreBootReasons(EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED);
         SuccessOrExit(err);
@@ -194,7 +194,7 @@ CHIP_ERROR ConfigurationManagerImpl::UpdateWiFiStationSecurityType(WiFiAuthSecur
     }
     else
     {
-        err = ClearConfigValue(PosixConfig::kConfigKey_WiFiStationSecType);
+        err = PosixConfig::ClearConfigValue(PosixConfig::kConfigKey_WiFiStationSecType);
         SuccessOrExit(err);
     }
 
@@ -275,7 +275,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
         ChipLogError(DeviceLayer, "Failed to factory reset configurations: %s", ErrorStr(err));
     }
 
-    err = FactoryResetCounters();
+    err = PosixConfig::FactoryResetCounters();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to factory reset counters: %s", ErrorStr(err));

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -37,6 +37,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<PosixConfig>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -53,18 +56,18 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Force initialization of NVS namespaces if they doesn't already exist.
-    err = EnsureNamespace(kConfigNamespace_ChipFactory);
+    err = EnsureNamespace(PosixConfig::kConfigNamespace_ChipFactory);
     SuccessOrExit(err);
-    err = EnsureNamespace(kConfigNamespace_ChipConfig);
+    err = EnsureNamespace(PosixConfig::kConfigNamespace_ChipConfig);
     SuccessOrExit(err);
-    err = EnsureNamespace(kConfigNamespace_ChipCounters);
+    err = EnsureNamespace(PosixConfig::kConfigNamespace_ChipCounters);
     SuccessOrExit(err);
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<PosixConfig>::Init();
     SuccessOrExit(err);
 
-    if (ConfigValueExists(kCounterKey_RebootCount))
+    if (ConfigValueExists(PosixConfig::kCounterKey_RebootCount))
     {
         err = GetRebootCount(rebootCount);
         SuccessOrExit(err);
@@ -79,13 +82,13 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    if (!ConfigValueExists(kCounterKey_TotalOperationalHours))
+    if (!ConfigValueExists(PosixConfig::kCounterKey_TotalOperationalHours))
     {
         err = StoreTotalOperationalHours(0);
         SuccessOrExit(err);
     }
 
-    if (!ConfigValueExists(kCounterKey_BootReason))
+    if (!ConfigValueExists(PosixConfig::kCounterKey_BootReason))
     {
         err = StoreBootReasons(EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED);
         SuccessOrExit(err);
@@ -144,7 +147,7 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
+    PosixConfig::Key configKey{ PosixConfig::kConfigNamespace_ChipCounters, key };
 
     CHIP_ERROR err = ReadConfigValue(configKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -156,7 +159,7 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
+    PosixConfig::Key configKey{ PosixConfig::kConfigNamespace_ChipCounters, key };
     return WriteConfigValue(configKey, value);
 }
 
@@ -166,7 +169,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetWiFiStationSecurityType(WiFiAuthSecurity
     CHIP_ERROR err;
     uint32_t secTypeInt;
 
-    err = ReadConfigValue(kConfigKey_WiFiStationSecType, secTypeInt);
+    err = ReadConfigValue(PosixConfig::kConfigKey_WiFiStationSecType, secTypeInt);
     if (err == CHIP_NO_ERROR)
     {
         secType = static_cast<WiFiAuthSecurityType>(secTypeInt);
@@ -185,13 +188,13 @@ CHIP_ERROR ConfigurationManagerImpl::UpdateWiFiStationSecurityType(WiFiAuthSecur
         if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || (err == CHIP_NO_ERROR && secType != curSecType))
         {
             uint32_t secTypeInt = static_cast<uint32_t>(secType);
-            err                 = WriteConfigValue(kConfigKey_WiFiStationSecType, secTypeInt);
+            err                 = WriteConfigValue(PosixConfig::kConfigKey_WiFiStationSecType, secTypeInt);
         }
         SuccessOrExit(err);
     }
     else
     {
-        err = ClearConfigValue(kConfigKey_WiFiStationSecType);
+        err = ClearConfigValue(PosixConfig::kConfigKey_WiFiStationSecType);
         SuccessOrExit(err);
     }
 
@@ -200,13 +203,73 @@ exit:
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
 
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, bool & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint32_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint64_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(PosixConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(PosixConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, bool val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint32_t val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint64_t val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str)
+{
+    return PosixConfig::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str, size_t strLen)
+{
+    return PosixConfig::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(PosixConfig::Key key, const uint8_t * data, size_t dataLen)
+{
+    return PosixConfig::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    PosixConfig::RunConfigUnitTest();
+}
+
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = FactoryResetConfig();
+    err = PosixConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to factory reset configurations: %s", ErrorStr(err));
@@ -232,32 +295,32 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 {
-    return ReadConfigValue(kCounterKey_RebootCount, rebootCount);
+    return ReadConfigValue(PosixConfig::kCounterKey_RebootCount, rebootCount);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
 {
-    return WriteConfigValue(kCounterKey_RebootCount, rebootCount);
+    return WriteConfigValue(PosixConfig::kCounterKey_RebootCount, rebootCount);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
-    return ReadConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
+    return ReadConfigValue(PosixConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
 {
-    return WriteConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
+    return WriteConfigValue(PosixConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetBootReasons(uint32_t & bootReasons)
 {
-    return ReadConfigValue(kCounterKey_BootReason, bootReasons);
+    return ReadConfigValue(PosixConfig::kCounterKey_BootReason, bootReasons);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreBootReasons(uint32_t bootReasons)
 {
-    return WriteConfigValue(kCounterKey_BootReason, bootReasons);
+    return WriteConfigValue(PosixConfig::kCounterKey_BootReason, bootReasons);
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -37,9 +37,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<PosixConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -203,57 +203,57 @@ exit:
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(PosixConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(PosixConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return PosixConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return PosixConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(PosixConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -34,8 +34,7 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Linux platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::PosixConfig
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
 public:
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
@@ -47,12 +46,6 @@ public:
     static ConfigurationManagerImpl & GetDefaultInstance();
 
 private:
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
     // ===== Members that implement the ConfigurationManager public interface.
 
     CHIP_ERROR Init() override;
@@ -68,6 +61,20 @@ private:
 #endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -103,7 +103,6 @@ public:
     static CHIP_ERROR FactoryResetCounters();
     static void RunConfigUnitTest();
 
-protected:
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);
     static CHIP_ERROR ClearNamespace(const char * ns);

--- a/src/platform/P6/ConfigurationManagerImpl.cpp
+++ b/src/platform/P6/ConfigurationManagerImpl.cpp
@@ -112,57 +112,57 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return PersistedStorage::KeyValueStoreMgr().Put(key, static_cast<void *>(&value), 4);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(P6Config::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return P6Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(P6Config::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return P6Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(P6Config::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return P6Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(P6Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return P6Config::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(P6Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return P6Config::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(P6Config::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return P6Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(P6Config::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return P6Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(P6Config::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return P6Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(P6Config::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return P6Config::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(P6Config::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return P6Config::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(P6Config::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return P6Config::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/P6/ConfigurationManagerImpl.cpp
+++ b/src/platform/P6/ConfigurationManagerImpl.cpp
@@ -33,9 +33,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<P6Config>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/P6/ConfigurationManagerImpl.cpp
+++ b/src/platform/P6/ConfigurationManagerImpl.cpp
@@ -33,6 +33,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<P6Config>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -48,7 +51,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<P6Config>::Init();
     VerifyOrReturnError(CHIP_NO_ERROR == err, err);
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
@@ -109,13 +112,73 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return PersistedStorage::KeyValueStoreMgr().Put(key, static_cast<void *>(&value), 4);
 }
 
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(P6Config::Key key, bool & val)
+{
+    return P6Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(P6Config::Key key, uint32_t & val)
+{
+    return P6Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(P6Config::Key key, uint64_t & val)
+{
+    return P6Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(P6Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return P6Config::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(P6Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return P6Config::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(P6Config::Key key, bool val)
+{
+    return P6Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(P6Config::Key key, uint32_t val)
+{
+    return P6Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(P6Config::Key key, uint64_t val)
+{
+    return P6Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(P6Config::Key key, const char * str)
+{
+    return P6Config::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(P6Config::Key key, const char * str, size_t strLen)
+{
+    return P6Config::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(P6Config::Key key, const uint8_t * data, size_t dataLen)
+{
+    return P6Config::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    P6Config::RunConfigUnitTest();
+}
+
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = FactoryResetConfig();
+    err = P6Config::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));

--- a/src/platform/P6/ConfigurationManagerImpl.h
+++ b/src/platform/P6/ConfigurationManagerImpl.h
@@ -35,15 +35,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the PSoC6 platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::P6Config
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::P6Config>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
@@ -59,6 +52,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -73,57 +73,57 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(PosixConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(PosixConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return PosixConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return PosixConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(PosixConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -34,6 +34,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<PosixConfig>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -45,7 +48,7 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 
 CHIP_ERROR ConfigurationManagerImpl::Init(void)
 {
-    return Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    return Internal::GenericConfigurationManagerImpl<PosixConfig>::Init();
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
@@ -68,6 +71,66 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, bool & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint32_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(PosixConfig::Key key, uint64_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(PosixConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(PosixConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, bool val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint32_t val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(PosixConfig::Key key, uint64_t val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str)
+{
+    return PosixConfig::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(PosixConfig::Key key, const char * str, size_t strLen)
+{
+    return PosixConfig::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(PosixConfig::Key key, const uint8_t * data, size_t dataLen)
+{
+    return PosixConfig::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    PosixConfig::RunConfigUnitTest();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -34,9 +34,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<PosixConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/Tizen/ConfigurationManagerImpl.h
+++ b/src/platform/Tizen/ConfigurationManagerImpl.h
@@ -34,15 +34,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Tizen platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::PosixConfig
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
@@ -58,6 +51,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -40,9 +40,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<ZephyrConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -40,6 +40,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<ZephyrConfig>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -55,7 +58,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<ZephyrConfig>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here
@@ -87,6 +90,66 @@ exit:
 void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ZephyrConfig::Key key, bool & val)
+{
+    return ZephyrConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ZephyrConfig::Key key, uint32_t & val)
+{
+    return ZephyrConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ZephyrConfig::Key key, uint64_t & val)
+{
+    return ZephyrConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(ZephyrConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return ZephyrConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(ZephyrConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return ZephyrConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ZephyrConfig::Key key, bool val)
+{
+    return ZephyrConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ZephyrConfig::Key key, uint32_t val)
+{
+    return ZephyrConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ZephyrConfig::Key key, uint64_t val)
+{
+    return ZephyrConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(ZephyrConfig::Key key, const char * str)
+{
+    return ZephyrConfig::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(ZephyrConfig::Key key, const char * str, size_t strLen)
+{
+    return ZephyrConfig::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(ZephyrConfig::Key key, const uint8_t * data, size_t dataLen)
+{
+    return ZephyrConfig::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    ZephyrConfig::RunConfigUnitTest();
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -92,57 +92,57 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ZephyrConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return ZephyrConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ZephyrConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return ZephyrConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(ZephyrConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return ZephyrConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(ZephyrConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return ZephyrConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(ZephyrConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return ZephyrConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ZephyrConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return ZephyrConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ZephyrConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return ZephyrConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(ZephyrConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return ZephyrConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(ZephyrConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return ZephyrConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(ZephyrConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return ZephyrConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(ZephyrConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return ZephyrConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -33,15 +33,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Zephyr platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::ZephyrConfig
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::ZephyrConfig>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
@@ -57,6 +50,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -77,12 +77,12 @@ inline bool ConfigurationManagerImpl::CanFactoryReset()
 
 inline CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    return ReadConfigValueCounter(key, value);
+    return Internal::ZephyrConfig::ReadConfigValueCounter(key, value);
 }
 
 inline CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    return WriteConfigValueCounter(key, value);
+    return Internal::ZephyrConfig::WriteConfigValueCounter(key, value);
 }
 
 inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * /* buf */)

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -97,12 +97,12 @@ public:
 
     static void RunConfigUnitTest();
 
+    static void InitializeWithObject(jobject managerObject);
+
 protected:
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);
     static CHIP_ERROR ClearNamespace(const char * ns);
-
-    static void InitializeWithObject(jobject managerObject);
 };
 
 struct AndroidConfig::Key

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -39,9 +39,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<AndroidConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -39,6 +39,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<AndroidConfig>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -84,6 +87,66 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AndroidConfig::Key key, bool & val)
+{
+    return AndroidConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AndroidConfig::Key key, uint32_t & val)
+{
+    return AndroidConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AndroidConfig::Key key, uint64_t & val)
+{
+    return AndroidConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(AndroidConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return AndroidConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(AndroidConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return AndroidConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AndroidConfig::Key key, bool val)
+{
+    return AndroidConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AndroidConfig::Key key, uint32_t val)
+{
+    return AndroidConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AndroidConfig::Key key, uint64_t val)
+{
+    return AndroidConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(AndroidConfig::Key key, const char * str)
+{
+    return AndroidConfig::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(AndroidConfig::Key key, const char * str, size_t strLen)
+{
+    return AndroidConfig::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(AndroidConfig::Key key, const uint8_t * data, size_t dataLen)
+{
+    return AndroidConfig::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    AndroidConfig::RunConfigUnitTest();
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -89,57 +89,57 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AndroidConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return AndroidConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AndroidConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return AndroidConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(AndroidConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return AndroidConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(AndroidConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return AndroidConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(AndroidConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return AndroidConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AndroidConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return AndroidConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AndroidConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return AndroidConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(AndroidConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return AndroidConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(AndroidConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return AndroidConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(AndroidConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return AndroidConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(AndroidConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return AndroidConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -35,15 +35,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Android platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::AndroidConfig
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::AndroidConfig>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
 public:
     void InitializeWithObject(jobject managerObject);
     static ConfigurationManagerImpl & GetDefaultInstance();
@@ -64,6 +57,20 @@ private:
 #endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -51,6 +51,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<CC13X2_26X2Config>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -89,7 +92,7 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    CC13X2_26X2Config::Key configKey{ { kCC13X2_26X2ChipCounters_Sysid, key } };
+    CC13X2_26X2Config::Key configKey{ { CC13X2_26X2Config::kCC13X2_26X2ChipCounters_Sysid, key } };
 
     CHIP_ERROR err = ReadConfigValue(configKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -101,8 +104,68 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    CC13X2_26X2Config::Key configKey{ { kCC13X2_26X2ChipCounters_Sysid, key } };
+    CC13X2_26X2Config::Key configKey{ { CC13X2_26X2Config::kCC13X2_26X2ChipCounters_Sysid, key } };
     return WriteConfigValue(configKey, value);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(CC13X2_26X2Config::Key key, bool & val)
+{
+    return CC13X2_26X2Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(CC13X2_26X2Config::Key key, uint32_t & val)
+{
+    return CC13X2_26X2Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(CC13X2_26X2Config::Key key, uint64_t & val)
+{
+    return CC13X2_26X2Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(CC13X2_26X2Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return CC13X2_26X2Config::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(CC13X2_26X2Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return CC13X2_26X2Config::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(CC13X2_26X2Config::Key key, bool val)
+{
+    return CC13X2_26X2Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(CC13X2_26X2Config::Key key, uint32_t val)
+{
+    return CC13X2_26X2Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(CC13X2_26X2Config::Key key, uint64_t val)
+{
+    return CC13X2_26X2Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(CC13X2_26X2Config::Key key, const char * str)
+{
+    return CC13X2_26X2Config::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(CC13X2_26X2Config::Key key, const char * str, size_t strLen)
+{
+    return CC13X2_26X2Config::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(CC13X2_26X2Config::Key key, const uint8_t * data, size_t dataLen)
+{
+    return CC13X2_26X2Config::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    CC13X2_26X2Config::RunConfigUnitTest();
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
@@ -111,7 +174,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = FactoryResetConfig();
+    err = CC13X2_26X2Config::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -108,57 +108,57 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return WriteConfigValue(configKey, value);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(CC13X2_26X2Config::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return CC13X2_26X2Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(CC13X2_26X2Config::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return CC13X2_26X2Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(CC13X2_26X2Config::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return CC13X2_26X2Config::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(CC13X2_26X2Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return CC13X2_26X2Config::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(CC13X2_26X2Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return CC13X2_26X2Config::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(CC13X2_26X2Config::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return CC13X2_26X2Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(CC13X2_26X2Config::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return CC13X2_26X2Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(CC13X2_26X2Config::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return CC13X2_26X2Config::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(CC13X2_26X2Config::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return CC13X2_26X2Config::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(CC13X2_26X2Config::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return CC13X2_26X2Config::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(CC13X2_26X2Config::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return CC13X2_26X2Config::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -51,9 +51,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<CC13X2_26X2Config>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.h
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.h
@@ -33,13 +33,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the CC13X2_26X2 platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::CC13X2_26X2Config
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::CC13X2_26X2Config>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
@@ -55,6 +50,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -39,6 +39,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<MbedConfig>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -110,13 +113,73 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    return WriteCounter(key, value);
+    return MbedConfig::WriteCounter(key, value);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(MbedConfig::Key key, bool & val)
+{
+    return MbedConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(MbedConfig::Key key, uint32_t & val)
+{
+    return MbedConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(MbedConfig::Key key, uint64_t & val)
+{
+    return MbedConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(MbedConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return MbedConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(MbedConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return MbedConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(MbedConfig::Key key, bool val)
+{
+    return MbedConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(MbedConfig::Key key, uint32_t val)
+{
+    return MbedConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(MbedConfig::Key key, uint64_t val)
+{
+    return MbedConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(MbedConfig::Key key, const char * str)
+{
+    return MbedConfig::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(MbedConfig::Key key, const char * str, size_t strLen)
+{
+    return MbedConfig::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(MbedConfig::Key key, const uint8_t * data, size_t dataLen)
+{
+    return MbedConfig::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    MbedConfig::RunConfigUnitTest();
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     ChipLogProgress(DeviceLayer, "Performing factory reset");
-    const CHIP_ERROR err = FactoryResetConfig();
+    const CHIP_ERROR err = MbedConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -39,9 +39,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<MbedConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -116,57 +116,57 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     return MbedConfig::WriteCounter(key, value);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(MbedConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return MbedConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(MbedConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return MbedConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(MbedConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return MbedConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(MbedConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return MbedConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(MbedConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return MbedConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(MbedConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return MbedConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(MbedConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return MbedConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(MbedConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return MbedConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(MbedConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return MbedConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(MbedConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return MbedConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(MbedConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return MbedConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/mbed/ConfigurationManagerImpl.h
+++ b/src/platform/mbed/ConfigurationManagerImpl.h
@@ -32,14 +32,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Zephyr platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::MbedConfig
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::MbedConfig>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
 
 public:
     // This returns an instance of this class.
@@ -56,6 +50,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -34,6 +34,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<K32W0Config>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -51,7 +54,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<K32W0Config>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here
@@ -113,13 +116,73 @@ exit:
     return err;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32W0Config::Key key, bool & val)
+{
+    return K32W0Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32W0Config::Key key, uint32_t & val)
+{
+    return K32W0Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32W0Config::Key key, uint64_t & val)
+{
+    return K32W0Config::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(K32W0Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return K32W0Config::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(K32W0Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return K32W0Config::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32W0Config::Key key, bool val)
+{
+    return K32W0Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32W0Config::Key key, uint32_t val)
+{
+    return K32W0Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32W0Config::Key key, uint64_t val)
+{
+    return K32W0Config::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(K32W0Config::Key key, const char * str)
+{
+    return K32W0Config::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(K32W0Config::Key key, const char * str, size_t strLen)
+{
+    return K32W0Config::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(K32W0Config::Key key, const uint8_t * data, size_t dataLen)
+{
+    return K32W0Config::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    K32W0Config::RunConfigUnitTest();
+}
+
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = FactoryResetConfig();
+    err = K32W0Config::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<K32W0Config>::Init();
+    err = Internal::GenericConfigurationManagerImpl<K32WConfig>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here
@@ -87,7 +87,7 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
 {
     CHIP_ERROR err;
 
-    err = ReadConfigValueCounter(persistedStorageKey, value);
+    err = K32WConfig::ReadConfigValueCounter(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -105,7 +105,7 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 
-    err = WriteConfigValueCounter(persistedStorageKey, value);
+    err = K32WConfig::WriteConfigValueCounter(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -116,64 +116,64 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32W0Config::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32WConfig::Key key, bool & val)
 {
-    return K32W0Config::ReadConfigValue(key, val);
+    return K32WConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32W0Config::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32WConfig::Key key, uint32_t & val)
 {
-    return K32W0Config::ReadConfigValue(key, val);
+    return K32WConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32W0Config::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32WConfig::Key key, uint64_t & val)
 {
-    return K32W0Config::ReadConfigValue(key, val);
+    return K32WConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(K32W0Config::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(K32WConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
 {
-    return K32W0Config::ReadConfigValueStr(key, buf, bufSize, outLen);
+    return K32WConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(K32W0Config::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(K32WConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
-    return K32W0Config::ReadConfigValueBin(key, buf, bufSize, outLen);
+    return K32WConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32W0Config::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32WConfig::Key key, bool val)
 {
-    return K32W0Config::WriteConfigValue(key, val);
+    return K32WConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32W0Config::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32WConfig::Key key, uint32_t val)
 {
-    return K32W0Config::WriteConfigValue(key, val);
+    return K32WConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32W0Config::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32WConfig::Key key, uint64_t val)
 {
-    return K32W0Config::WriteConfigValue(key, val);
+    return K32WConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(K32W0Config::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(K32WConfig::Key key, const char * str)
 {
-    return K32W0Config::WriteConfigValueStr(key, str);
+    return K32WConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(K32W0Config::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(K32WConfig::Key key, const char * str, size_t strLen)
 {
-    return K32W0Config::WriteConfigValueStr(key, str, strLen);
+    return K32WConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(K32W0Config::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(K32WConfig::Key key, const uint8_t * data, size_t dataLen)
 {
-    return K32W0Config::WriteConfigValueBin(key, data, dataLen);
+    return K32WConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
 void ConfigurationManagerImpl::RunConfigUnitTest(void)
 {
-    K32W0Config::RunConfigUnitTest();
+    K32WConfig::RunConfigUnitTest();
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
@@ -182,7 +182,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = K32W0Config::FactoryResetConfig();
+    err = K32WConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -35,7 +35,7 @@
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
-template class GenericConfigurationManagerImpl<K32W0Config>;
+template class GenericConfigurationManagerImpl<K32WConfig>;
 } // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
@@ -116,57 +116,57 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32WConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return K32WConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32WConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return K32WConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(K32WConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return K32WConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(K32WConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return K32WConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(K32WConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return K32WConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32WConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return K32WConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32WConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return K32WConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(K32WConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return K32WConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(K32WConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return K32WConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(K32WConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return K32WConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(K32WConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return K32WConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -34,9 +34,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<K32WConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
@@ -34,15 +34,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the K32W platform.
  */
-class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                       private Internal::K32WConfig
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<Internal::K32WConfig>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
@@ -58,6 +51,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/nxp/k32w/k32w0/K32W0Config.cpp
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.cpp
@@ -468,6 +468,8 @@ exit:
     return err;
 }
 
+void K32WConfig::RunConfigUnitTest() {}
+
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -117,57 +117,57 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(QPGConfig::Key key, bool & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
     return QPGConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(QPGConfig::Key key, uint32_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return QPGConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(QPGConfig::Key key, uint64_t & val)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
     return QPGConfig::ReadConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(QPGConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     return QPGConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(QPGConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     return QPGConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(QPGConfig::Key key, bool val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
     return QPGConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(QPGConfig::Key key, uint32_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
     return QPGConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(QPGConfig::Key key, uint64_t val)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
     return QPGConfig::WriteConfigValue(key, val);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(QPGConfig::Key key, const char * str)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
     return QPGConfig::WriteConfigValueStr(key, str);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(QPGConfig::Key key, const char * str, size_t strLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     return QPGConfig::WriteConfigValueStr(key, str, strLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(QPGConfig::Key key, const uint8_t * data, size_t dataLen)
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
     return QPGConfig::WriteConfigValueBin(key, data, dataLen);
 }

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -117,6 +117,66 @@ exit:
     return err;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(QPGConfig::Key key, bool & val)
+{
+    return QPGConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(QPGConfig::Key key, uint32_t & val)
+{
+    return QPGConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(QPGConfig::Key key, uint64_t & val)
+{
+    return QPGConfig::ReadConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(QPGConfig::Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    return QPGConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(QPGConfig::Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    return QPGConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(QPGConfig::Key key, bool val)
+{
+    return QPGConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(QPGConfig::Key key, uint32_t val)
+{
+    return QPGConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(QPGConfig::Key key, uint64_t val)
+{
+    return QPGConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(QPGConfig::Key key, const char * str)
+{
+    return QPGConfig::WriteConfigValueStr(key, str);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(QPGConfig::Key key, const char * str, size_t strLen)
+{
+    return QPGConfig::WriteConfigValueStr(key, str, strLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(QPGConfig::Key key, const uint8_t * data, size_t dataLen)
+{
+    return QPGConfig::WriteConfigValueBin(key, data, dataLen);
+}
+
+void ConfigurationManagerImpl::RunConfigUnitTest(void)
+{
+    QPGConfig::RunConfigUnitTest();
+}
+
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -38,9 +38,6 @@
 
 namespace chip {
 namespace DeviceLayer {
-namespace Internal {
-template class GenericConfigurationManagerImpl<QPGConfig>;
-} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -38,6 +38,9 @@
 
 namespace chip {
 namespace DeviceLayer {
+namespace Internal {
+template class GenericConfigurationManagerImpl<QPGConfig>;
+} // namespace Internal
 
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -53,7 +56,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
+    err = Internal::GenericConfigurationManagerImpl<QPGConfig>::Init();
     SuccessOrExit(err);
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
@@ -83,9 +86,9 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
                                                                uint32_t & value)
 {
     CHIP_ERROR err;
-    uintmax_t recordKey = persistedStorageKey + kConfigKey_GroupKeyBase;
+    uintmax_t recordKey = persistedStorageKey + QPGConfig::kConfigKey_GroupKeyBase;
 
-    VerifyOrExit(recordKey <= kConfigKey_GroupKeyMax, err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrExit(recordKey <= QPGConfig::kConfigKey_GroupKeyMax, err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     err = ReadConfigValue(persistedStorageKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -103,9 +106,9 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform
 {
     CHIP_ERROR err;
 
-    uintmax_t recordKey = persistedStorageKey + kConfigKey_GroupKeyBase;
+    uintmax_t recordKey = persistedStorageKey + QPGConfig::kConfigKey_GroupKeyBase;
 
-    VerifyOrExit(recordKey <= kConfigKey_GroupKeyMax, err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrExit(recordKey <= QPGConfig::kConfigKey_GroupKeyMax, err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     err = WriteConfigValue(persistedStorageKey, value);
     SuccessOrExit(err);
@@ -121,7 +124,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = FactoryResetConfig();
+    err = QPGConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));

--- a/src/platform/qpg/ConfigurationManagerImpl.h
+++ b/src/platform/qpg/ConfigurationManagerImpl.h
@@ -32,15 +32,8 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the platform.
  */
-class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
-                                 private Internal::QPGConfig
+class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::QPGConfig>
 {
-    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
-    // defined on this class.
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-#endif
-
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
@@ -56,6 +49,20 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR ReadConfigValue(Key key, bool & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint32_t & val) override;
+    CHIP_ERROR ReadConfigValue(Key key, uint64_t & val) override;
+    CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen) override;
+    CHIP_ERROR WriteConfigValue(Key key, bool val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint32_t val) override;
+    CHIP_ERROR WriteConfigValue(Key key, uint64_t val) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
+    CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
+    CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
+    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 


### PR DESCRIPTION
#### Problem
The CRTP in the ConfigurationManager is hiding an interface that it depends on, as well as makes it more challenging to make subclasses of the platform-specific ConfigurationManager implementations.

#### Change overview
* Make the methods that deal with the configuration values an explicit part of the GenericConfigurationManagerImpl interface. Add implementations of these to each platform.
* Replace the ImplClass template parameter with a class that specifies the type of and defines the keys used.
* Remove all remaining Impl() calls in GenericConfigurationManagerImpl.

#### Testing
Ran the unit tests.