### PR TITLE
Add a simple implementation of storage for ACLs.

### DIFF
--- a/src/access/examples/ExampleAccessControlDelegate.h
+++ b/src/access/examples/ExampleAccessControlDelegate.h
@@ -17,12 +17,15 @@
 #pragma once
 
 #include "access/AccessControl.h"
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 
 namespace chip {
 namespace Access {
 namespace Examples {
 
 AccessControl::Delegate & GetAccessControlDelegate();
+
+void SetAccessControlDelegateStorage(chip::PersistentStorageDelegate * storageDelegate);
 
 } // namespace Examples
 } // namespace Access

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -33,6 +33,11 @@ public:
 
     const char * FabricTable(chip::FabricIndex fabric) { return Format("f/%x/t", fabric); }
 
+    // Access Control List
+
+    const char * AccessControlList() { return Format("acl"); }
+    const char * AccessControlEntry(size_t index) { return Format("acl/%x", index); }
+
     // Group Data Provider
 
     const char * FabricGroups(chip::FabricIndex fabric) { return Format("f/%x/g", fabric); }


### PR DESCRIPTION
It uses a persistent storage delegate to store the data as a simple binary blob.
Platforms or applications that want content-aware storage should implement their
own version of the AccessControl::Delegate interface et al.

#### Problem
The example implementation of the access control Delegate interface is missing any usage of storage, although it contains hooks where the ACLs can be stored and loaded. In order to make the access control example complete it should interact with storage.

#### Change overview
* Add a new globally-accessible method to set the storage delegate for the example access control delegate.
* Store/load the data with a version tag that can be used to ensure that invalid data isn't loaded when the format changes.

#### Testing
* Running the existing tests.